### PR TITLE
Update baseimage and mumble

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER David Coppit <david@coppit.org>
 
 RUN apt-add-repository ppa:mumble/release \
 	&& apt-get update \
-	&& apt-get install -y mumble-server=1.3.2-1~ppa1~bionic1
+	&& apt-get install -y mumble-server=1.3.3-1~ppa1~bionic1
 
 # Add the start script
 ADD start.sh /tmp/start.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
-FROM phusion/baseimage:0.9.22
+FROM phusion/baseimage:bionic-1.0.0
 
 MAINTAINER David Coppit <david@coppit.org>
 
-RUN apt-add-repository ppa:mumble/release
-RUN apt-get update
-RUN apt-get install -y mumble-server=1.2.19-1~ppa4~xenial1 
+RUN apt-add-repository ppa:mumble/release \
+	&& apt-get update \
+	&& apt-get install -y mumble-server=1.3.2-1~ppa1~bionic1
 
 # Add the start script
 ADD start.sh /tmp/start.sh
+
 RUN chmod 755 /tmp/start.sh
 
 VOLUME ["/data"]


### PR DESCRIPTION
Update baseimage to bionic-1.0.0 and mumble to 1.3.2-1\~ppa1\~bionic1.

The current server version is very old and causes a security warning in modern Mumble clients.